### PR TITLE
Annoying deprecation warning from Numpy

### DIFF
--- a/pysparse/sparse/pysparseMatrix.py
+++ b/pysparse/sparse/pysparseMatrix.py
@@ -282,7 +282,7 @@ class PysparseMatrix(SparseMatrix):
 
     def __rmul__(self, other):
         # Compute  other * A  which is really  A^T * other
-        if type(numpy.ones(1.0)) == type(other):
+        if type(numpy.ones(1)) == type(other):
             M, N = self.getShape()
             y = numpy.empty(N)
             self.matrix.matvec_transp(other, y)


### PR DESCRIPTION
``` python
numpy.ones(1.0)
```

results in a deprecation warning from Numpy

```
numpy/core/numeric.py:183: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
```
